### PR TITLE
Marmiton don't have a "h3" anymore in steps

### DIFF
--- a/marmiton/__init__.py
+++ b/marmiton/__init__.py
@@ -116,7 +116,6 @@ class Marmiton(object):
 		steps = []
 		soup_steps = soup.find_all("li", {"class": "recipe-preparation__list__item"})
 		for soup_step in soup_steps:
-			soup_step.find("h3").decompose()
 			steps.append(Marmiton.__clean_text(soup_step))
 
 		image = soup.find("img", {"id": "af-diapo-desktop-0_img"})['src'] if soup.find("img", {"id": "af-diapo-desktop-0_img"}) else ""


### PR DESCRIPTION
Removed "h3" finder and decomposer for steps

Without fix :
![sample_without_fix](https://user-images.githubusercontent.com/17902872/75116219-515e2a00-5666-11ea-901f-a9c0b8637a42.png)

With fix :
![sample_with_fix](https://user-images.githubusercontent.com/17902872/75116217-4f946680-5666-11ea-9cfe-50a01bc03e11.png)

